### PR TITLE
chore: bump version

### DIFF
--- a/.github/workflows/pr-semver-bump.yml
+++ b/.github/workflows/pr-semver-bump.yml
@@ -23,8 +23,7 @@ jobs:
       - name: 🏷️ Determine Version Bump Type from Labels
         id: version
         run: |
-          labels=$(curl -s -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-            https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels)
+          labels=$(curl -s -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels)
           if echo "$labels" | grep -q '"name": "major"'; then
             echo "type=major" >> $GITHUB_OUTPUT
           elif echo "$labels" | grep -q '"name": "minor"'; then


### PR DESCRIPTION
- fixed malformed quoting in node -p version evaluation
- ensures proper tag creation and push without shell syntax error
