### PR TITLE
chore: clean up Codecov workflow

### DIFF
--- a/.github/workflows/upload-codecov.yml
+++ b/.github/workflows/upload-codecov.yml
@@ -32,9 +32,3 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ${{ inputs.clover-path }}
           fail_ci_if_error: ${{ inputs.fail_ci_if_error }}
-
-      - name: Upload test results to Codecov
-        if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@v1
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Removed redundant step for uploading test results to Codecov. Simplified the workflow by eliminating unnecessary actions while maintaining functionality. Tests results only support JUnit reports for now.
