### PR TITLE
build(ci): add caching and improve version bump logic

### DIFF
--- a/.github/workflows/pr-semver-bump.yml
+++ b/.github/workflows/pr-semver-bump.yml
@@ -38,6 +38,13 @@ jobs:
         with:
           node-version: 20
 
+      - name: 🔹 Cache Dependencies
+        id: node-cache
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+
       - name: 📥 Install Dependencies
         run: npm ci
 
@@ -50,13 +57,13 @@ jobs:
           VERSION=$(node -p 'require("./package.json").version')
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "branch=release/v$VERSION" >> $GITHUB_OUTPUT
-          git checkout -b release/v$VERSION
+          git checkout -B release/v$VERSION
 
-      - name: 💬 Commit and Push to Release Branch
+      - name: 💬 Commit and Force Push to Release Branch
         run: |
           git add package.json package-lock.json CHANGELOG.md
           git commit -m "chore(release): bump version [skip ci]"
-          git push origin release/v${{ steps.version_branch.outputs.version }}
+          git push --force-with-lease origin release/v${{ steps.version_branch.outputs.version }}
 
       - name: 📬 Create Pull Request
         uses: peter-evans/create-pull-request@v5

--- a/.github/workflows/tag-on-merge.yml
+++ b/.github/workflows/tag-on-merge.yml
@@ -7,11 +7,12 @@ on:
       - main
 
 jobs:
-  tag-version:
+  tag-release:
+    name: 🔖 Tag Merged Version
     runs-on: ubuntu-latest
 
     steps:
-      - name: 💾 Checkout main branch
+      - name: 💾 Checkout Repository
         uses: actions/checkout@v4
 
       - name: 🔧 Setup Git User
@@ -19,19 +20,21 @@ jobs:
           git config user.name "github-actions"
           git config user.email "github-actions@github.com"
 
-      - name: 🧪 Validate it's a version bump
+      - name: 🧪 Detect Version Bump Commit
         id: check
         run: |
-          LAST_COMMIT=$(git log -1 --pretty=%B)
-          echo "Last commit: $LAST_COMMIT"
-          if [[ "$LAST_COMMIT" != *"chore(release): bump version"* ]]; then
-            echo "❌ Not a version bump commit. Skipping tag."
-            echo "skip=true" >> $GITHUB_OUTPUT
+          COMMIT_MSG=$(git log -1 --pretty=%B)
+          echo "Last commit message: $COMMIT_MSG"
+          if [[ "$COMMIT_MSG" == chore(release):* ]]; then
+            echo "is_bump=true" >> $GITHUB_OUTPUT
+          else
+            echo "is_bump=false" >> $GITHUB_OUTPUT
           fi
 
-      - name: 🔖 Create and Push Tag
-        if: steps.check.outputs.skip != 'true'
+      - name: 🔖 Create and Push Git Tag
+        if: steps.check.outputs.is_bump == 'true'
         run: |
           VERSION=$(node -p 'require("./package.json").version')
+          echo "Creating tag: v$VERSION"
           git tag "v$VERSION"
           git push origin "v$VERSION"


### PR DESCRIPTION
- Added caching for node modules to speed up installs.
- Changed branch checkout command to force create a new branch.
- Updated commit push command to use force-with-lease for safety.
- Renamed job for tagging merged versions and improved clarity in steps.
- Enhanced version bump detection logic for better accuracy.
