### PR TITLE
fix: change PR merge strategy to auto-merge

### DIFF
--- a/.github/workflows/pr-semver-bump.yml
+++ b/.github/workflows/pr-semver-bump.yml
@@ -87,4 +87,4 @@ jobs:
         run: |
           PR_URL=$(gh pr view --json url -q .url)
           echo "ℹ️ Enabling auto-merge for PR: $PR_URL"
-          gh pr merge --auto --squash
+          gh pr merge --auto --merge


### PR DESCRIPTION
Updated the workflow to use auto-merge instead of squash for pull requests. This simplifies the commit history by keeping individual commits intact during merging.
