### PR TITLE
fix: update release artifact path

### DIFF
--- a/.github/workflows/gh-release.yml
+++ b/.github/workflows/gh-release.yml
@@ -89,7 +89,7 @@ jobs:
           gh release create "${{ github.event.client_payload.tag }}" \
             --title "Release ${{ github.event.client_payload.tag }}" \
             --notes-file notes/RELEASE_NOTES.md \
-            build/**
+            dist/**
 
       - name: 📦 Setup npm Authentication
         run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc


### PR DESCRIPTION
Changed the release artifact path from `build/**` to `dist/**` in the GitHub Actions workflow. This ensures the correct files are included in the release process.
